### PR TITLE
Rename config.yml  to config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml 
+++ b/.github/ISSUE_TEMPLATE/config.yml 
@@ -1,1 +1,0 @@
-blank_issues_enabled: false


### PR DESCRIPTION
remove space from config.yml to fix clone problem on windows

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                               |
| New feature?  | no                                                                    |
| Deprecations? | no                                                                        |
| Issues        | Fix #105 |
| License       | **MIT**                                                                                                                       |

<!--
fixed clone problem with ending space on windows


Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->